### PR TITLE
[fix] git ci flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,8 @@
             ]
         },
         "dmg": {
-            "title": "飞牛影视 ${version}",
+            "title": "FNMedia_${version}_${arch}",
             "icon": "build/icon.icns",
-            "volume": "FNMedia_${version}_${arch}",
             "window": {
                 "width": 540,
                 "height": 380


### PR DESCRIPTION
1. 添加证书信任模块，修复未信任证书导致登录失败
2. 修复不同操作系统更新提示时，点击下载后下载的文件都为exe