### PR TITLE
[fix] git ci flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,9 +183,13 @@ jobs:
       - name: Get commit info
         id: commit
         run: |
-          echo "message<<EOF" >> $GITHUB_OUTPUT
-          git log -1 --pretty=format:'%B' >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+              echo "message<<EOF"
+              git log -1 --pretty=%B
+              echo
+              echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
 
       - name: Get package version
         id: package


### PR DESCRIPTION
1. 添加证书信任模块，修复未信任证书导致登录失败
2. 修复不同操作系统更新提示时，点击下载后下载的文件都为exe