### PR TITLE
[opt] library page not refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fntv",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "description": "A fntv app built with Electron",
     "main": "dest/main/main.js",
     "scripts": {

--- a/src/main/common/utils.ts
+++ b/src/main/common/utils.ts
@@ -1,0 +1,7 @@
+
+
+// 检查当前页面是否为资源库页面
+export function checkLibraryPageUrl(url: string) {
+    if (!url) return false;
+    return url.includes('/v/library/');
+}

--- a/src/main/handlers/plugins/media.ts
+++ b/src/main/handlers/plugins/media.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs';
 import { PlayStatusData } from '../../../modules/fn_api/types';
 import { escape } from 'querystring';
 import { isTrusted } from '../../../modules/cert_trust';
+import { checkLibraryPageUrl } from '../../common/utils';
 
 /**
 * 媒体播放插件
@@ -96,6 +97,12 @@ function getMpvPlayerPath(): string | undefined {
 
 // 刷新窗口
 async function refreshWindow(): Promise<void> {
+    const currentURL = BrowserWindow.getFocusedWindow()?.webContents.getURL() || '';
+    // 如果是资源库页面则不刷新
+    if (checkLibraryPageUrl(currentURL)) {
+        return;
+    }
+
     log.info('刷新所有窗口');
     try {
         const allWindows = BrowserWindow.getAllWindows();


### PR DESCRIPTION
1.优化：资源预览页面退出mpv后不刷新，防止失去当前视频位置。