### PR TITLE
[fix] mac build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,18 @@
     "main": "dest/main/main.js",
     "scripts": {
         "build:proxy:win": "cd src/modules/proxy && go build -o ../../../third_party/proxy/proxy.exe",
-        "build:proxy:other": "cd src/modules/proxy && go build -o ../../../third_party/proxy/proxy",
+        "build:proxy:linux": "cd src/modules/proxy && go build -o ../../../third_party/proxy/proxy",
+        "build:proxy:mac:x64": "cd src/modules/proxy && GOOS=darwin GOARCH=amd64 go build -o ../../../third_party/proxy/proxy_x64",
+        "build:proxy:mac:arm64": "cd src/modules/proxy && GOOS=darwin GOARCH=arm64 go build -o ../../../third_party/proxy/proxy_arm64",
+        "build:proxy:mac:universal": "lipo -create -output third_party/proxy/proxy third_party/proxy/proxy_x64 third_party/proxy/proxy_arm64",
+        "clean:proxy:mac": "rimraf third_party/proxy/proxy_x64 third_party/proxy/proxy_arm64",
         "start": "npm run clean && npm run build:proxy:win && tsc && electron .",
         "compile": "tsc",
         "watch": "tsc --watch",
         "clean": "rimraf dest",
-        "build:win": "npm run build:proxy:win && tsc && electron-builder --win",
-        "build:mac": "npm run build:proxy:other && tsc && electron-builder --mac",
-        "build:linux": "npm run build:proxy:other && tsc && electron-builder --linux"
+        "build:win": "npm-run-all -s build:proxy:win compile && electron-builder --win",
+        "build:mac": "npm-run-all -s build:proxy:mac:x64 build:proxy:mac:arm64 build:proxy:mac:universal compile clean:proxy:mac && electron-builder --mac",
+        "build:linux": "npm-run-all -s build:proxy:linux compile && electron-builder --linux"
     },
     "author": "tracing",
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fntv",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "description": "A fntv app built with Electron",
     "main": "dest/main/main.js",
     "scripts": {


### PR DESCRIPTION
1.修复: mpv崩溃导致主界面意外刷新。
2.修复: 部分场景跳转函数未响应，导致无法正确上报播放进度。
3.修复: 点击剧集页面的某一集的播放按钮，未正确播放对应集内容。
4.修复: 不同架构mac无法正常运行proxy进程