### PR TITLE
Use native macOS window controls

### DIFF
--- a/src/main/common/mainwin.ts
+++ b/src/main/common/mainwin.ts
@@ -1,6 +1,8 @@
 import { BrowserWindow, BrowserWindowConstructorOptions } from 'electron';
 import * as path from 'path';
 
+const isMac = process.platform === 'darwin';
+
 const mainwinConfig: BrowserWindowConstructorOptions = {
     width: 1400,
     height: 800,
@@ -9,7 +11,13 @@ const mainwinConfig: BrowserWindowConstructorOptions = {
     autoHideMenuBar: true,
     show: false,
     icon: path.join(__dirname, '../../../build/icon.ico'),
-    frame: false,
+    // macOS 使用系统交通灯按钮，但让现有页面继续延伸到标题栏区域。
+    // Windows/Linux 保持原有的无边框窗口和自定义窗口按钮。
+    frame: isMac,
+    ...(isMac && {
+        titleBarStyle: 'hiddenInset' as const,
+        trafficLightPosition: { x: 14, y: 14 },
+    }),
     // transparent: true,
     webPreferences: {
         webgl: true,

--- a/src/modules/fn_api/request.ts
+++ b/src/modules/fn_api/request.ts
@@ -159,7 +159,8 @@ export async function request<T = any>(
             }
 
             // 不是json直接返回二进制文件
-            if (response.headers['content-type'] && !response.headers['content-type'].includes('application/json')) {
+            const contentType = response.headers['content-type'];
+            if (typeof contentType === 'string' && !contentType.includes('application/json')) {
                 return {
                     success: true,
                     data: response.data as any, // 直接返回原始数据

--- a/src/preload/plugins/titlebar.ts
+++ b/src/preload/plugins/titlebar.ts
@@ -8,6 +8,8 @@ function injectTitleBar(): void {
     logger.info('Injecting custom title bar...');
     if (document.getElementById('custom-titlebar')) return;
 
+    const isMac = process.platform === 'darwin';
+
     const bar = document.createElement('div');
     bar.id = 'custom-titlebar';
     bar.style.cssText = `
@@ -26,7 +28,9 @@ function injectTitleBar(): void {
         transition: background 0.3s ease;
     `;
 
-    bar.innerHTML = `
+    // macOS 的按钮由系统窗口绘制，这里只保留透明拖动区域。
+    // 其他平台继续使用原来的自定义窗口控制按钮。
+    bar.innerHTML = isMac ? '' : `
         <div id="titlebar-btns" style="-webkit-app-region:no-drag; display:flex; gap:2px; padding-right:4px;">
             <button id="min-btn" style="
                 background:transparent; 
@@ -84,6 +88,8 @@ function injectTitleBar(): void {
     // 防止出现双重滚动条
     document.documentElement.style.overflowY = 'hidden';
     document.body.appendChild(bar);
+
+    if (isMac) return;
 
     // 按钮交互效果
     const buttonIds: string[] = ['min-btn', 'max-btn', 'close-btn'];


### PR DESCRIPTION
## Summary

- use the native macOS traffic-light window controls with an inset hidden title bar
- preserve the existing renderer UI and transparent draggable title-bar region on macOS
- keep the existing frameless custom controls unchanged on Windows and Linux
- safely narrow Axios `content-type` headers before string matching

## Validation

- `npm run compile`
- `npm run build:mac`
- verified the macOS arm64 app bundle and nested helpers with `codesign --verify --deep --strict`
